### PR TITLE
Browsable API

### DIFF
--- a/bimbingbung/settings/base.py
+++ b/bimbingbung/settings/base.py
@@ -153,5 +153,7 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_PARSER_CLASSES': (
         'rest_framework.parsers.JSONParser',
+        'rest_framework.parsers.FormParser',
+        'rest_framework.parsers.MultiPartParser',
     )
 }

--- a/bimbingbung/urls.py
+++ b/bimbingbung/urls.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
+from rest_framework.routers import DefaultRouter
 
 from search import views as search_views
 from content import views as content_views
@@ -12,6 +13,11 @@ from wagtail.wagtailcore import urls as wagtail_urls
 from wagtail.wagtaildocs import urls as wagtaildocs_urls
 
 
+router = DefaultRouter()
+router.register(r'challenges', content_views.ChallengeViewSet)
+router.register(r'tips', content_views.TipViewSet)
+router.register(r'users', user_views.RegUserViewSet)
+
 urlpatterns = [
     url(r'^django-admin/', include(admin.site.urls)),
 
@@ -20,14 +26,7 @@ urlpatterns = [
 
     url(r'^search/$', search_views.search, name='search'),
 
-    url(r'^api/challenges/?$', content_views.ChallengeViewSet.as_view({'get': 'list'})),
-    url(r'^api/challenges/(?P<pk>[0-9]+)/?$', content_views.ChallengeViewSet.as_view({'get': 'retrieve'})),
-
-    url(r'^api/tips/$', content_views.TipViewSet.as_view({'get': 'list'}), name='tip-list'),
-    url(r'^api/tips/(?P<pk>[0-9]+)/$', content_views.TipViewSet.as_view({'get': 'retrieve'}), name='tip-detail'),
-
-    url(r'^api/users/$', user_views.RegUserViewSet.as_view({'get': 'list', 'post': 'create'}), name='user-list'),
-    url(r'^api/users/(?P<pk>[0-9]+)/$', user_views.RegUserViewSet.as_view({'get': 'retrieve'}), name='user-detail'),
+    url(r'^api/', include(router.urls, namespace='api')),
 
     url(r'', include(wagtail_urls)),
 ]

--- a/bimbingbung/urls.py
+++ b/bimbingbung/urls.py
@@ -14,9 +14,9 @@ from wagtail.wagtaildocs import urls as wagtaildocs_urls
 
 
 router = DefaultRouter()
-router.register(r'challenges', content_views.ChallengeViewSet)
-router.register(r'tips', content_views.TipViewSet)
-router.register(r'users', user_views.RegUserViewSet)
+router.register(r'challenges', content_views.ChallengeViewSet, base_name='challenges')
+router.register(r'tips', content_views.TipViewSet, base_name='tips')
+router.register(r'users', user_views.RegUserViewSet, base_name='users')
 
 urlpatterns = [
     url(r'^django-admin/', include(admin.site.urls)),

--- a/content/tests.py
+++ b/content/tests.py
@@ -82,7 +82,7 @@ class TestTipAPI(APITestCase):
         live_tip = create_tip(title='Live tip')
         publish_page(self.user, live_tip)
 
-        response = self.client.get(reverse('tip-list'))
+        response = self.client.get(reverse('api:tips-list'))
         data = json.loads(response.content.decode('utf-8'))
         self.assertEqual(Tip.objects.all().count(), 2, 'Test did not set up Tip pages correctly.')
         self.assertEqual(len(data), 1, 'View returned more than one Tip.')

--- a/content/views.py
+++ b/content/views.py
@@ -12,11 +12,11 @@ class ChallengeViewSet(viewsets.ModelViewSet):
     http_method_names = ('options', 'get',)
 
     def list(self, request, *args, **kwargs):
-        serializer = ChallengeSerializer(Challenge.objects.all(), many=True)
+        serializer = self.get_serializer(self.get_queryset(), many=True)
         return Response(serializer.data)
 
     def retrieve(self, request, pk=None, *args, **kwargs):
-        serializer = ChallengeSerializer(Challenge.objects.get(pk=pk))
+        serializer = self.get_serializer(get_object_or_404(self.get_queryset(), pk=pk))
         return Response(serializer.data)
 
 

--- a/content/views.py
+++ b/content/views.py
@@ -9,7 +9,7 @@ from .serializers import ChallengeSerializer, TipSerializer
 class ChallengeViewSet(viewsets.ModelViewSet):
     queryset = Challenge.objects.all()
     serializer_class = ChallengeSerializer
-    http_method_names = ('options', 'get',)
+    http_method_names = ('options', 'head', 'get',)
 
     def list(self, request, *args, **kwargs):
         serializer = self.get_serializer(self.get_queryset(), many=True)
@@ -25,7 +25,7 @@ class TipViewSet(viewsets.ModelViewSet):
     """
     queryset = Tip.objects.all()
     serializer_class = TipSerializer
-    http_method_names = ('options', 'get',)
+    http_method_names = ('options', 'head', 'get',)
 
     def list(self, request, *args, **kwargs):
         serializer = self.get_serializer(self.get_queryset().filter(live=True), many=True)

--- a/content/views.py
+++ b/content/views.py
@@ -1,5 +1,4 @@
 from django.shortcuts import get_object_or_404
-from rest_framework.renderers import JSONRenderer, BrowsableAPIRenderer
 from rest_framework import viewsets
 from rest_framework.response import Response
 from .models import Challenge, Tip
@@ -10,15 +9,15 @@ from .serializers import ChallengeSerializer, TipSerializer
 class ChallengeViewSet(viewsets.ModelViewSet):
     queryset = Challenge.objects.all()
     serializer_class = ChallengeSerializer
-    renderer_classes = (JSONRenderer,)
+    http_method_names = ('options', 'get',)
 
     def list(self, request, *args, **kwargs):
         serializer = ChallengeSerializer(Challenge.objects.all(), many=True)
-        return Response(JSONRenderer().render(serializer.data))
+        return Response(serializer.data)
 
     def retrieve(self, request, pk=None, *args, **kwargs):
         serializer = ChallengeSerializer(Challenge.objects.get(pk=pk))
-        return Response(JSONRenderer().render(serializer.data))
+        return Response(serializer.data)
 
 
 class TipViewSet(viewsets.ModelViewSet):
@@ -26,6 +25,7 @@ class TipViewSet(viewsets.ModelViewSet):
     """
     queryset = Tip.objects.all()
     serializer_class = TipSerializer
+    http_method_names = ('options', 'get',)
 
     def list(self, request, *args, **kwargs):
         serializer = self.get_serializer(self.get_queryset().filter(live=True), many=True)

--- a/users/views.py
+++ b/users/views.py
@@ -2,7 +2,6 @@ from django.shortcuts import render
 
 # Create your views here.
 from django.shortcuts import get_object_or_404
-from rest_framework.renderers import JSONRenderer
 from rest_framework import viewsets
 from rest_framework.response import Response
 from .models import RegUser
@@ -13,7 +12,7 @@ from .serializers import RegUserDeepSerializer
 class RegUserViewSet(viewsets.ModelViewSet):
     queryset = RegUser.objects.all()
     serializer_class = RegUserDeepSerializer
-    renderer_classes = (JSONRenderer,)
+    http_method_names = ('options', 'get', 'post',)
 
     def list(self, request, *args, **kwargs):
         serializer = self.get_serializer(self.get_queryset(), many=True)

--- a/users/views.py
+++ b/users/views.py
@@ -12,7 +12,7 @@ from .serializers import RegUserDeepSerializer
 class RegUserViewSet(viewsets.ModelViewSet):
     queryset = RegUser.objects.all()
     serializer_class = RegUserDeepSerializer
-    http_method_names = ('options', 'get', 'post',)
+    http_method_names = ('options', 'head', 'get', 'post',)
 
     def list(self, request, *args, **kwargs):
         serializer = self.get_serializer(self.get_queryset(), many=True)


### PR DESCRIPTION
This pull request cleans up the setup of Django Rest Framework to enable the built in browsable API. By registering the REST routes using a DefaultRouter, we get a root view that will list the available REST resource urls.
