### PR TITLE
Write only password field

### DIFF
--- a/users/serializers.py
+++ b/users/serializers.py
@@ -48,7 +48,7 @@ class RegUserDeepSerializer(serializers.ModelSerializer):
     class Meta:
         model = RegUser
         depth = 1
-        exclude = ('password',)
+        extra_kwargs = {'password': {'write_only': True}}
 
     def __init__(self, *args, **kwargs):
         super(RegUserDeepSerializer, self).__init__(*args, **kwargs)
@@ -62,6 +62,10 @@ class RegUserDeepSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         user_data = validated_data
         profile_data = validated_data.pop('profile')
+        password = validated_data.pop('password')
         user = RegUser.objects.create(**user_data)
+        # Required to hash password
+        user.set_password(password)
+        user.save()
         profile = Profile.objects.create(user=user, **profile_data)
         return user

--- a/users/views.py
+++ b/users/views.py
@@ -21,7 +21,6 @@ class RegUserViewSet(viewsets.ModelViewSet):
 
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
-        if serializer.is_valid():
+        if serializer.is_valid(raise_exception=True):
             serializer.save()
             return Response({'success': True, 'id': serializer.instance.pk})
-        return Response({'success': False, 'errors': serializer.errors}, status=400)


### PR DESCRIPTION
Fixes the issue where the password was not saved on user registration via the endpoint; still excluded from the list view.

As discussed @rjacobs31, please review.
