### PR TITLE
Added password change endpoint which requires the old password

### DIFF
--- a/users/exceptions.py
+++ b/users/exceptions.py
@@ -1,0 +1,9 @@
+
+from django.utils.translation import ugettext_lazy as _
+from rest_framework import status
+from rest_framework.exceptions import APIException
+
+
+class PasswordNotMatching(APIException):
+    status_code = status.HTTP_400_BAD_REQUEST
+    default_detail = _('Provided old password did not match existing password.')

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -82,7 +82,20 @@ class RegUserDeepSerializer(serializers.ModelSerializer):
         return user
 
     def update(self, instance, validated_data):
+        # TODO: Do not allow password to be updated via RegUserDeepSerializer
         password = validated_data.pop('password', None)
         if password:
             instance.set_password(password)
         return super(RegUserDeepSerializer, self).update(instance, validated_data)
+
+
+class PasswordChangeSerializer(serializers.Serializer):
+    old_password = serializers.CharField()
+    new_password = serializers.CharField()
+
+    class Meta:
+        fields = '__all__'
+        extra_kwargs = {
+            'old_password': {'write_only': True},
+            'new_password': {'write_only': True}
+        }

--- a/users/views.py
+++ b/users/views.py
@@ -1,4 +1,7 @@
+
 from django.shortcuts import get_object_or_404
+from django.http import HttpResponseBadRequest
+
 from rest_framework import status
 from rest_framework import viewsets
 from rest_framework.authtoken.models import Token
@@ -13,7 +16,7 @@ from sendfile import sendfile
 
 from .models import RegUser, User
 from .permissions import IsUserSelf, IsRegisteringOrSelf
-from .serializers import RegUserDeepSerializer
+from .serializers import RegUserDeepSerializer, PasswordChangeSerializer
 
 
 class ProfileImageView(GenericAPIView):
@@ -71,6 +74,16 @@ class RegUserViewSet(viewsets.ModelViewSet):
         serializer = self.get_serializer(obj, data=request.data, partial=True)
         if serializer.is_valid(raise_exception=True):
             serializer.save()
+            return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @detail_route(methods=['post'])
+    def password(self, request, pk=None, *args, **kwargs):
+        serializer = PasswordChangeSerializer(data=request.data, context=self.get_serializer_context())
+        if serializer.is_valid(raise_exception=True):
+            if not request.user.check_password(serializer.validated_data['old_password']):
+                return HttpResponseBadRequest('Provided old password did not match existing password.')
+            request.user.set_password(serializer.validated_data['new_password'])
+            request.user.save()
             return Response(status=status.HTTP_204_NO_CONTENT)
 
 

--- a/users/views.py
+++ b/users/views.py
@@ -1,6 +1,5 @@
 
 from django.shortcuts import get_object_or_404
-from django.http import HttpResponseBadRequest
 
 from rest_framework import status
 from rest_framework import viewsets
@@ -14,6 +13,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from sendfile import sendfile
 
+from .exceptions import PasswordNotMatching
 from .models import RegUser, User
 from .permissions import IsUserSelf, IsRegisteringOrSelf
 from .serializers import RegUserDeepSerializer, PasswordChangeSerializer
@@ -81,7 +81,7 @@ class RegUserViewSet(viewsets.ModelViewSet):
         serializer = PasswordChangeSerializer(data=request.data, context=self.get_serializer_context())
         if serializer.is_valid(raise_exception=True):
             if not request.user.check_password(serializer.validated_data['old_password']):
-                return HttpResponseBadRequest('Provided old password did not match existing password.')
+                raise PasswordNotMatching()
             request.user.set_password(serializer.validated_data['new_password'])
             request.user.save()
             return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
### Request

Method: `POST`
Route: `/api/users/{id}/password/`
Request Body:
```json
{
	"old_password": "{old password}",
	"new_password": "{new password}"
}
```

### Response

Responds with `HTTP 204 No Content` on success.

### Error

When the provided old password does not match the existing password, the response is `HTTP 400 Bad Request`.

```json
{
  "status_code": 400,
  "errors": [
    "Provided old password did not match existing password."
  ],
  "rel_errors": {},
  "field_errors": {}
}
```