### PR TITLE
Fix Allowed Hosts

### DIFF
--- a/bimbingbung/settings/dev.py
+++ b/bimbingbung/settings/dev.py
@@ -12,6 +12,9 @@ SECRET_KEY = 'eh+r*5&#=5a_w!ln_5yux2_d69v73q71n6j!=+x16^6z48p^w$'
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 
+ALLOWED_HOSTS = ['10.0.2.2']
+
+
 # SENDFILE settings
 
 SENDFILE_BACKEND = 'sendfile.backends.development'

--- a/bimbingbung/settings/dev.py
+++ b/bimbingbung/settings/dev.py
@@ -12,7 +12,11 @@ SECRET_KEY = 'eh+r*5&#=5a_w!ln_5yux2_d69v73q71n6j!=+x16^6z48p^w$'
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 
-ALLOWED_HOSTS = ['10.0.2.2']
+ALLOWED_HOSTS = [
+    'localhost',
+    '127.0.0.1',
+    '10.0.2.2',  # Host address on Android Emulator
+]
 
 
 # SENDFILE settings


### PR DESCRIPTION
`ALLOWED_HOSTS` is now required as of Django 1.10.4

Previously we were using 1.10.2 which did not enforce `ALLOWED_HOSTS` in Debug mode.