### PR TITLE
GEMINDO-129/ Ensure displaying winning Picture Challenges in a Tip Listicle works as expected

### DIFF
--- a/content/templates/content/tip.html
+++ b/content/templates/content/tip.html
@@ -33,7 +33,7 @@ prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns
 
 {% block content %}
     <div id="article">
-        <h1>{{ page.title.upper }}</h1>
+        <h1 style="overflow-wrap: break-word;">{{ page.title.upper }}</h1>
         <h5>{% trans "Written for you, by Bina." %}</h5>
 
     <ul id="tip-tags" class="clearfix">


### PR DESCRIPTION
Added overflow-wrap to the heading element