### PR TITLE
Bugfix/Report Issues

### DIFF
--- a/content/models.py
+++ b/content/models.py
@@ -1114,6 +1114,10 @@ class Goal(models.Model):
     @property
     def progress(self):
         """Returns the progress of the Goal's savings as percentage."""
+
+        if int(self.target) == 0:
+            return 0
+
         return int((self.value / self.target) * 100)
 
     @property

--- a/content/reports.py
+++ b/content/reports.py
@@ -789,23 +789,30 @@ class ChallengeExportFreetext:
                 participants = Participant.objects.filter(challenge=challenge)
 
                 for participant in participants:
-                    participant_free_text = ParticipantFreeText.objects.get(participant=participant)
                     profile = Profile.objects.get(user=participant.user)
 
-                    data = [
-                        participant.user.username,
-                        participant.user.first_name,
-                        profile.mobile,
-                        participant.user.email,
-                        profile.gender,
-                        profile.age,
-                        '',  # user type
-                        participant.date_created,
-                        participant_free_text.text,
-                        participant_free_text.date_answered
-                    ]
+                    # With a free text challenge, there can be a participant but no entry
+                    # This try/catch prevents a crash for when the user has started a challenge but not submitted an entry
+                    try:
+                        participant_free_text = ParticipantFreeText.objects.get(participant=participant)
 
-                    append_to_csv(data, csvfile)
+                        data = [
+                            participant.user.username,
+                            participant.user.first_name,
+                            profile.mobile,
+                            participant.user.email,
+                            profile.gender,
+                            profile.age,
+                            '',  # user type
+                            participant.date_created,
+                            participant_free_text.text,
+                            participant_free_text.date_answered
+                        ]
+
+                        append_to_csv(data, csvfile)
+
+                    except ParticipantFreeText.DoesNotExist:
+                        pass
 
         success, message = pass_zip_encrypt_email(request, export_name, unique_time)
 

--- a/content/reports.py
+++ b/content/reports.py
@@ -1415,20 +1415,26 @@ class SummarySurveyData:
             # Counts number of first conversation no responses, others checks to see if they have no consent
             for survey in submitted_surveys:
                 submission_data = json.loads(survey.submission_data)
-                if submission_data['survey_baseline_intro'] == '0':
-                    num_first_convo_no += 1
-                elif survey.consent is False:
-                    num_no_consent += 1
-                elif survey.complete is False:
-                    num_in_progress_users += 1
+                try:
+                    if submission_data['survey_baseline_intro'] == '0':
+                        num_first_convo_no += 1
+                    elif survey.consent is False:
+                        num_no_consent += 1
+                    elif survey.complete is False:
+                        num_in_progress_users += 1
+                except KeyError:
+                    pass
 
             submitted_surveys = CoachSurveySubmissionDraft.objects.filter(survey__bot_conversation=CoachSurvey.BASELINE)
 
             for survey in submitted_surveys:
                 if survey.submission is not None:
                     survey_data = survey.submission.get_data()
-                    if survey_data['survey_baseline_q1_consent'] == 1:
-                        num_claim_over_17_users += 1
+                    try:
+                        if survey_data['survey_baseline_q1_consent'] == 1:
+                            num_claim_over_17_users += 1
+                    except KeyError:
+                        pass
 
             num_total_users = User.objects.all().count()
             num_participated_survey = CoachSurveySubmissionDraft.objects\
@@ -1467,20 +1473,26 @@ class SummarySurveyData:
             # Counts number of first conversation no responses, others checks to see if they have no consent
             for survey in submitted_surveys:
                 submission_data = json.loads(survey.submission_data)
-                if submission_data['survey_eatool_intro'] == '0':
-                    num_first_convo_no += 1
-                elif survey.consent is False:
-                    num_no_consent += 1
-                elif survey.complete is False:
-                    num_in_progress_users += 1
+                try:
+                    if submission_data['survey_eatool_intro'] == '0':
+                        num_first_convo_no += 1
+                    elif survey.consent is False:
+                        num_no_consent += 1
+                    elif survey.complete is False:
+                        num_in_progress_users += 1
+                except KeyError:
+                    pass
 
             submitted_surveys = CoachSurveySubmissionDraft.objects.filter(survey__bot_conversation=CoachSurvey.EATOOL)
 
             for survey in submitted_surveys:
                 if survey.submission is not None:
                     survey_data = survey.submission.get_data()
-                    if survey_data['survey_eatool_q1_consent'] == 1:
-                        num_claim_over_17_users += 1
+                    try:
+                        if survey_data['survey_eatool_q1_consent'] == 1:
+                            num_claim_over_17_users += 1
+                    except KeyError:
+                        pass
 
             num_total_users = User.objects.all().count()
             num_participated_survey = CoachSurveySubmissionDraft.objects \

--- a/content/reports.py
+++ b/content/reports.py
@@ -1409,11 +1409,11 @@ class SummarySurveyData:
             num_no_consent = 0
             num_claim_over_17_users = 0
 
-            submitted_surveys = CoachSurveySubmissionDraft.objects.filter(survey__bot_conversation=CoachSurvey.BASELINE,
-                                                                          consent=False)
+            submitted_survey_drafts = CoachSurveySubmissionDraft.objects.filter(survey__bot_conversation=CoachSurvey.BASELINE,
+                                                                                consent=False)
 
             # Counts number of first conversation no responses, others checks to see if they have no consent
-            for survey in submitted_surveys:
+            for survey in submitted_survey_drafts:
                 submission_data = json.loads(survey.submission_data)
                 try:
                     if submission_data['survey_baseline_intro'] == '0':
@@ -1425,25 +1425,24 @@ class SummarySurveyData:
                 except KeyError:
                     pass
 
-            submitted_surveys = CoachSurveySubmissionDraft.objects.filter(survey__bot_conversation=CoachSurvey.BASELINE)
+            submitted_surveys = CoachSurveySubmission.objects.filter(survey__bot_conversation=CoachSurvey.BASELINE)
 
             for survey in submitted_surveys:
-                if survey.submission is not None:
-                    survey_data = survey.submission.get_data()
-                    try:
-                        if survey_data['survey_baseline_q1_consent'] == 1:
-                            num_claim_over_17_users += 1
-                    except KeyError:
-                        pass
+                survey_data = survey.get_data()
+                try:
+                    if survey_data['survey_baseline_q1_consent'] == 1:
+                        num_claim_over_17_users += 1
+                except KeyError:
+                    pass
 
             num_total_users = User.objects.all().count()
-            num_participated_survey = CoachSurveySubmissionDraft.objects\
+            num_participated_survey = CoachSurveySubmission.objects\
                 .filter(survey__bot_conversation=CoachSurvey.BASELINE)\
                 .values('user')\
                 .distinct()\
                 .count()
 
-            num_no_engagement = num_total_users - num_participated_survey
+            num_no_engagement = num_total_users - num_participated_survey - num_first_convo_no
 
             data = [
                 'Baseline Survey',
@@ -1467,11 +1466,11 @@ class SummarySurveyData:
             num_no_consent = 0
             num_claim_over_17_users = 0
 
-            submitted_surveys = CoachSurveySubmissionDraft.objects.filter(survey__bot_conversation=CoachSurvey.EATOOL,
-                                                                          consent=False)
+            submitted_survey_drafts = CoachSurveySubmissionDraft.objects.filter(survey__bot_conversation=CoachSurvey.EATOOL,
+                                                                                consent=False)
 
             # Counts number of first conversation no responses, others checks to see if they have no consent
-            for survey in submitted_surveys:
+            for survey in submitted_survey_drafts:
                 submission_data = json.loads(survey.submission_data)
                 try:
                     if submission_data['survey_eatool_intro'] == '0':
@@ -1501,7 +1500,7 @@ class SummarySurveyData:
                 .distinct() \
                 .count()
 
-            num_no_engagement = num_total_users - num_participated_survey
+            num_no_engagement = num_total_users - num_participated_survey - num_first_convo_no
 
             data = [
                 'EA Tool 1 Survey',

--- a/content/views.py
+++ b/content/views.py
@@ -163,7 +163,9 @@ class ChallengeViewSet(viewsets.ModelViewSet):
         """Returns true if notification should be shown, and false otherwise"""
 
         try:
-            challenge = Challenge.objects.get(state=Challenge.CST_PUBLISHED)
+            challenge = Challenge.objects.get(state=Challenge.CST_PUBLISHED,
+                                              activation_date__lt=timezone.now(),
+                                              deactivation_date__gt=timezone.now())
         except:
             return Response({"available": False})
 


### PR DESCRIPTION
Fixed the following issues with reports:
- Checking the goal progress resulted in a divide by zero error
- Set up badges on the QA and production server so that identified by type now
- Freetext challenges had a problem where users started the challenge but did not submit, causing the reports to look for an unavailable submission

Unrelated issue fixed:
- Challenge participation notifications were only checking if a challenge was published or not, and not if it was within its activation/deactivation date. This is now fixed.