### PR TITLE
Set maximum file upload size to 10MB

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,5 +1,6 @@
 server {
     listen 80 default;
+    client_max_body_size=10m;
 
     # static
     location ^~ /static/ {


### PR DESCRIPTION
By default, the nginx max file size is 1MB.