### PR TITLE
Commented out tip tags appearing on tip articles

### DIFF
--- a/content/templates/content/tip.html
+++ b/content/templates/content/tip.html
@@ -36,11 +36,11 @@ prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns
         <h1 style="overflow-wrap: break-word;">{{ page.title.upper }}</h1>
         <h5>{% trans "Written for you, by Bina." %}</h5>
 
-    <ul id="tip-tags" class="clearfix">
-        {% for tag in page.tags.all %}
-        <li class="tip-tag">{{ tag.name.upper }}</li>
-        {% endfor %}
-    </ul>
+    <!--<ul id="tip-tags" class="clearfix">-->
+        <!--{% for tag in page.tags.all %}-->
+        <!--<li class="tip-tag">{{ tag.name.upper }}</li>-->
+        <!--{% endfor %}-->
+    <!--</ul>-->
 
     <div id="slider" class="swipe">
         <div class="swipe-wrap">


### PR DESCRIPTION
It was not possible to make the tip tags a navigable feature in the Tip screen, so as allowed by the QA feedback they were removed.