### PR TITLE
Budget Edit Badge Crash

### DIFF
--- a/content/tests.py
+++ b/content/tests.py
@@ -2044,13 +2044,36 @@ class TestBadgeAwarding(APITestCase):
         badges = [b for b in response.data['badges'] if b['name'] == self.budget_creation.name]
         self.assertEqual(len(badges), 1, "Budget creation badge not included")
 
-
     # ----------------- #
     # Award Budget Edit #
     # ----------------- #
 
-    def test_budget_edit(self):
-        self.skipTest('TODO')
+    def test_budget_edit_income(self):
+        user = create_test_regular_user()
+        budget = Budget.objects.create(
+            user=user,
+            income=100000,
+            savings=30000
+        )
+        budget.expenses.create(value=20000)
+        budget.expenses.create(value=50000)
+        budget.expenses.create(value=70000)
+        budget.save()
+
+        data = {
+            'income': 700000
+        }
+
+        self.client.force_authenticate(user=user)
+
+        response = self.client.patch(reverse('api:budgets-detail', kwargs={'pk': budget.id}),
+                                     data=data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, "Income edit failed")
+        self.assertEqual(len(response.data['badges']), 1, "No badges returned")
+        badges = [b for b in response.data['badges'] if b['name'] == self.budget_edit.name]
+
+        self.assertEqual(len(badges), 1, "Budget edit badge not included")
 
 
 class TestNotification(APITestCase):

--- a/content/tests.py
+++ b/content/tests.py
@@ -2020,6 +2020,38 @@ class TestBadgeAwarding(APITestCase):
         self.assertEqual(response.data['badge']['name'], self.challenge_win.name, "Unexpected Badge returned.")
         self.assertEqual(response.data['challenge']['id'], challenge.id, "Unexpected Challenge returned.")
 
+    # --------------------- #
+    # Award Budget Creation #
+    # --------------------- #
+
+    def test_budget_create(self):
+        user = create_test_regular_user('anon')
+        data = {
+            'income': 100000,
+            'savings': 40000,
+            'expenses': [
+                {'name': 'Food', 'value': 20000},
+                {'name': 'Shoes', 'value': 10000},
+            ]
+        }
+
+        self.client.force_authenticate(user=user)
+
+        response = self.client.post(reverse('api:budgets-list'), data, format='json')
+
+        self.assertEqual(len(response.data.get('badges')), 1, "No badges returned")
+
+        badges = [b for b in response.data['badges'] if b['name'] == self.budget_creation.name]
+        self.assertEqual(len(badges), 1, "Budget creation badge not included")
+
+
+    # ----------------- #
+    # Award Budget Edit #
+    # ----------------- #
+
+    def test_budget_edit(self):
+        self.skipTest('TODO')
+
 
 class TestNotification(APITestCase):
     def test_notification(self):

--- a/content/tests.py
+++ b/content/tests.py
@@ -2075,6 +2075,33 @@ class TestBadgeAwarding(APITestCase):
 
         self.assertEqual(len(badges), 1, "Budget edit badge not included")
 
+    def test_budget_edit_savings(self):
+        user = create_test_regular_user()
+        budget = Budget.objects.create(
+            user=user,
+            income=100000,
+            savings=30000
+        )
+        budget.expenses.create(value=20000)
+        budget.expenses.create(value=50000)
+        budget.expenses.create(value=70000)
+        budget.save()
+
+        data = {
+            'savings': 40000
+        }
+
+        self.client.force_authenticate(user=user)
+
+        response = self.client.patch(reverse('api:budgets-detail', kwargs={'pk': budget.id}),
+                                     data=data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, "Savings edit failed")
+        self.assertEqual(len(response.data['badges']), 1, "No badges returned")
+        badges = [b for b in response.data['badges'] if b['name'] == self.budget_edit.name]
+
+        self.assertEqual(len(badges), 1, "Budget edit badge not included")
+
 
 class TestNotification(APITestCase):
     def test_notification(self):

--- a/content/views.py
+++ b/content/views.py
@@ -872,15 +872,13 @@ class BudgetView(viewsets.ModelViewSet):
                 'badges': badges
             }, status=status.HTTP_201_CREATED)
 
-    @detail_route(methods=['post', 'patch'])
+    @detail_route(methods=['post'])
     def expenses(self, request, pk):
         """Allows expenses to be added or edited in bulk. Accepts a Budget's list of expenses. This functionality has
         been split from the Budget upsert in order to award the Budget Edit Badge. Expenses are identified by their
         category, and so the `category_id` must be included.
 
         Method POST will compare the list's categories and add expenses with new categories.
-
-        Method PATCH will update the values of existing expenses, but not add any new ones.
 
         :return The entire updated budget
         """
@@ -907,8 +905,6 @@ class BudgetView(viewsets.ModelViewSet):
                     'budget': self.get_serializer(instance=self.get_object()).data,
                     'badges': UserBadgeSerializer(instance=[b for b in badges if b is not None], many=True, context=self.get_serializer_context()).data
                 }, status=status.HTTP_201_CREATED)
-        elif request.method == 'PATCH':
-            pass
         else:
             raise MethodNotAllowed(request.method)
 
@@ -925,8 +921,6 @@ class ExpenseView(viewsets.ModelViewSet):
     @list_route(['delete'])
     def delete(self, request, *args, **kwargs):
         delete_list = request.data.getlist('ids')
-        print('delete_list')
-        print(delete_list)
         for expense_id in delete_list:
             obj = Expense.objects.get(id=expense_id)
             self.check_object_permissions(request, obj)

--- a/content/views.py
+++ b/content/views.py
@@ -905,7 +905,7 @@ class BudgetView(viewsets.ModelViewSet):
 
                 return Response({
                     'budget': self.get_serializer(instance=self.get_object()).data,
-                    'badges': [b for b in badges if b is not None]
+                    'badges': UserBadgeSerializer(instance=[b for b in badges if b is not None], many=True, context=self.get_serializer_context()).data
                 }, status=status.HTTP_201_CREATED)
         elif request.method == 'PATCH':
             pass

--- a/content/views.py
+++ b/content/views.py
@@ -843,12 +843,13 @@ class BudgetView(viewsets.ModelViewSet):
             budget = serializer.save()
 
             badge = award_budget_create(request, serializer.instance)
-
-            user_badge = UserBadgeSerializer(instance=badge, context=self.get_serializer_context()).data
+            badges = []
+            if badge:
+                badges.append(UserBadgeSerializer(instance=badge, context=self.get_serializer_context()).data)
 
             return Response({
                 'budget': self.get_serializer(instance=budget).data,
-                'badges': [user_badge]
+                'badges': badges
             }, status=status.HTTP_201_CREATED)
 
     def list(self, request, *args, **kwargs):
@@ -864,12 +865,13 @@ class BudgetView(viewsets.ModelViewSet):
             budget = serializer.save()
 
             badge = award_budget_edit(request, serializer.instance)
-
-            user_badge = UserBadgeSerializer(instance=badge, context=self.get_serializer_context()).data
+            badges = []
+            if badge:
+                badges.append(UserBadgeSerializer(instance=badge, context=self.get_serializer_context()).data)
 
             return Response({
                 'budget': self.get_serializer(instance=budget).data,
-                'badges': [user_badge]
+                'badges': badges
             }, status=status.HTTP_201_CREATED)
 
 

--- a/content/views.py
+++ b/content/views.py
@@ -40,7 +40,7 @@ from .serializers import GoalPrototypeSerializer, GoalSerializer, GoalTransactio
 from .serializers import ParticipantAnswerSerializer, ParticipantFreeTextSerializer, ParticipantPictureSerializer, \
     ParticipantRegisterSerializer
 from .serializers import TipSerializer
-from .serializers import ExpenseCategorySerializer, BudgetSerializer
+from .serializers import ExpenseCategorySerializer, ExpenseSerializer, BudgetSerializer
 
 
 # ========== #
@@ -317,11 +317,11 @@ class ParticipantViewSet(viewsets.ModelViewSet):
         if not Goal.objects.filter(user=request.user).exists():
             return Response({"available": False, "challenge": None})
 
-        challenge = Challenge.objects\
+        challenge = Challenge.objects \
             .filter(state=Challenge.CST_PUBLISHED,
                     activation_date__lte=timezone.now(),
-                    deactivation_date__gte=timezone.now())\
-            .order_by('activation_date')\
+                    deactivation_date__gte=timezone.now()) \
+            .order_by('activation_date') \
             .first()
 
         '''Returns True so the challenge pop up is not shown'''
@@ -842,7 +842,7 @@ class BudgetView(viewsets.ModelViewSet):
         if serializer.is_valid(raise_exception=True):
             budget = serializer.save()
 
-            badge = award_budget_create(request, serializer.instance)
+            badge = award_budget_create(request, budget)
             badges = []
             if badge:
                 badges.append(UserBadgeSerializer(instance=badge, context=self.get_serializer_context()).data)
@@ -859,8 +859,6 @@ class BudgetView(viewsets.ModelViewSet):
     def partial_update(self, request, pk=None, *args, **kwargs):
         serializer = self.get_serializer(instance=self.get_object(), data=request.data, partial=True)
         if serializer.is_valid(raise_exception=True):
-            # serializer.save()
-            # return Response(data=serializer.data, status=status.HTTP_200_OK)
 
             budget = serializer.save()
 
@@ -873,6 +871,46 @@ class BudgetView(viewsets.ModelViewSet):
                 'budget': self.get_serializer(instance=budget).data,
                 'badges': badges
             }, status=status.HTTP_201_CREATED)
+
+    @detail_route(methods=['post', 'patch'])
+    def expenses(self, request, pk):
+        """Allows expenses to be added or edited in bulk. Accepts a Budget's list of expenses. This functionality has
+        been split from the Budget upsert in order to award the Budget Edit Badge. Expenses are identified by their
+        category, and so the `category_id` must be included.
+
+        Method POST will compare the list's categories and add expenses with new categories.
+
+        Method PATCH will update the values of existing expenses, but not add any new ones.
+
+        :return The entire updated budget
+        """
+
+        if request.method == 'POST':
+            serializer = ExpenseSerializer(data=request.data, many=True)
+            if serializer.is_valid(raise_exception=True):
+                badges = []
+                budget = self.get_object()
+                existing_expenses_categories = {ex.category.id for ex in budget.expenses.all()}
+
+                exps = [Expense(category=datum.pop('category_id', None), **datum) for datum in serializer.validated_data]
+                added = False
+                for ex in exps:
+                    if ex.category_id not in existing_expenses_categories:
+                        budget.expenses.add(ex)
+                        added = True
+
+                if added:
+                    budget.save()
+                    badges.append(award_budget_edit(request, budget))
+
+                return Response({
+                    'budget': self.get_serializer(instance=self.get_object()).data,
+                    'badges': [b for b in badges if b is not None]
+                }, status=status.HTTP_201_CREATED)
+        elif request.method == 'PATCH':
+            pass
+        else:
+            raise MethodNotAllowed(request.method)
 
 
 class ExpenseView(viewsets.ModelViewSet):


### PR DESCRIPTION
This PR addresses the problem where adding Expenses during the Budget Edit conversation does not award an Edit Badge. It adds a new endpoint specifically for adding Expenses. The old Budget level upsert is still in place.